### PR TITLE
reimplementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ keywords = ["async", "future", "waitgroup"]
 
 [dependencies]
 futures-util = "0.3.3"
-
+tokio = { version = "0.2",features = ["full"] }
+futures="0.3"
 [dev-dependencies]
-tokio = { version = "0.2.11", features = ["full"] }
+
 futures-timer = "3.0.1"

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -19,12 +19,13 @@ async fn wait_group_version() {
         let count = count.clone();
 
         tokio::spawn(async move {
+            println!("in spawn");
             count.fetch_add(1, Ordering::SeqCst);
             wg.done().await;
         });
     }
 
-    wg.await;
+    wg.wait().await;
 
     assert_eq!(count.load(Ordering::SeqCst), 10);
 }

--- a/tests/await_with_done.rs
+++ b/tests/await_with_done.rs
@@ -22,7 +22,7 @@ async fn test_await() {
         });
     }
 
-    wg.await;
+    wg.wait().await;
 
     assert_eq!(count.load(Ordering::SeqCst), 10);
 }
@@ -30,7 +30,7 @@ async fn test_await() {
 #[tokio::test]
 async fn test_await_empty() {
     let wg = WaitGroup::new();
-    wg.await;
+    wg.wait().await;
 }
 
 #[tokio::test]
@@ -49,7 +49,7 @@ async fn test_await_add() {
         });
     }
 
-    wg.await;
+    wg.wait().await;
 
     assert_eq!(count.load(Ordering::SeqCst), 10);
 }
@@ -61,7 +61,7 @@ async fn test_await_complex() {
 
     for _ in 0..10 {
         let wg = wg.clone();
-        wg.add(1).await;
+        wg.add(2).await;
         let count = count.clone();
 
         tokio::spawn(async move {
@@ -70,7 +70,6 @@ async fn test_await_complex() {
             delay_for(Duration::from_millis(1)).await;
 
             let wg0 = wg.clone();
-            wg0.add(1).await;
 
             tokio::spawn(async move {
                 count.fetch_add(1, Ordering::SeqCst);
@@ -84,7 +83,7 @@ async fn test_await_complex() {
         });
     }
 
-    wg.await;
+    wg.wait().await;
 
     assert_eq!(count.load(Ordering::SeqCst), 20);
 }

--- a/tests/await_without_done.rs
+++ b/tests/await_without_done.rs
@@ -1,6 +1,5 @@
 use async_wg::WaitGroup;
 use futures_timer::Delay;
-use futures_util::future::{select, Either};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::{sync::Arc, time::Duration};
@@ -21,9 +20,9 @@ async fn test_await() {
             wg.done().await;
         });
     }
-
-    match select(wg, Delay::new(Duration::from_secs(1))).await {
-        Either::Left(_) => assert!(false),
-        Either::Right(_) => assert!(true),
+    use futures::*;
+    select! {
+        _=wg.wait().fuse()=> assert!(false),
+        _=Delay::new(Duration::from_secs(1)).fuse()=>assert!(true),
     }
 }

--- a/tests/multi_wg.rs
+++ b/tests/multi_wg.rs
@@ -40,8 +40,8 @@ async fn main() {
         });
     }
 
-    a_wg.await;
-    b_wg.await;
+    a_wg.wait().await;
+    b_wg.wait().await;
 
     assert_eq!(a_count.load(Ordering::SeqCst), 10);
     assert_eq!(b_count.load(Ordering::SeqCst), 10);


### PR DESCRIPTION
原来的0.1.2版本的问题我已经写在了
https://github.com/nkbai/learnrustbynats/blob/wait-group/bench/src/wait_group.rs

关键是futures的Mutex根本不适合用在Future中，应该是设计问题，意图不一样。
在我的电脑上，我这个版本的benchmark
```
running 1 test
test bench_join_handle ... bench:      44,691 ns/iter (+/- 12,215)
running 1 test
test bench_wait_group  ... bench:      44,930 ns/iter (+/- 11,352)
```

0.1.2的benchmark
```
running 1 test
test bench_join_handle ... bench:      38,031 ns/iter (+/- 15,217)

running 1 test
test bench_wait_group  ... bench:      44,696 ns/iter (+/- 12,761)
```